### PR TITLE
fix: same id problem

### DIFF
--- a/src/vue-tinymce.vue
+++ b/src/vue-tinymce.vue
@@ -34,7 +34,7 @@ export default {
     },
     data(){
         return {
-            id: 'vue-tinymce-'+Date.now(),
+            id: 'vue-tinymce-'+Date.now()+Math.floor(Math.random() * 1000),
             editor: null,
             status: INIT,
             backup: ''


### PR DESCRIPTION
使用 v-for 循环创建组件时，组件初始化会出现相同 id 的情况（尤其是在性能较好的 PC）。